### PR TITLE
Improve file writer history

### DIFF
--- a/src/hidra/sender/eventdetectors/http_events.py
+++ b/src/hidra/sender/eventdetectors/http_events.py
@@ -207,9 +207,11 @@ class EventDetectorImpl:
     def get_new_event(self):
         """Implementation of the abstract method get_new_event.
         """
-
-        files_stored = self._get_files_stored()
-        if not files_stored:
+        try:
+            files_stored = self._get_files_stored()
+        except Exception:
+            self.log.error("Error in getting file list from %s",
+                           self.file_writer_url, exc_info=True)
             # Wait till next try to prevent denial of service
             time.sleep(self.sleep_time)
             return []
@@ -226,12 +228,7 @@ class EventDetectorImpl:
         return event_message_list
 
     def _get_files_stored(self):
-        try:
-            files_stored = self.connection.get_file_list(self.file_writer_url)
-        except Exception:
-            self.log.error("Error in getting file list from %s",
-                           self.file_writer_url, exc_info=True)
-            return []
+        files_stored = self.connection.get_file_list(self.file_writer_url)
 
         # api version 1.8.0 and newer return a dictionary instead of a list
         if isinstance(files_stored, dict):

--- a/src/hidra/sender/eventdetectors/http_events.py
+++ b/src/hidra/sender/eventdetectors/http_events.py
@@ -142,7 +142,7 @@ class EventDetector(EventDetectorBase):
         self.check_config()
 
         self.event_detector_impl = create_eventdetector_impl(
-            **self.config, log=self.log)
+            log=self.log, **self.config)
 
     def get_new_event(self):
         """Implementation of the abstract method get_new_event.

--- a/src/hidra/sender/eventdetectors/http_events.py
+++ b/src/hidra/sender/eventdetectors/http_events.py
@@ -101,14 +101,13 @@ class FileFilterSet:
         self.files_seen = set()
 
     def get_new_files(self, files_stored):
-        files_stored_set = set(files_stored)
-        new_files = files_stored_set - self.files_seen
-        self.files_seen = files_stored_set
-
         filtered_files = []
-        for file_obj in new_files:
-            if file_obj.startswith(self.fix_subdirs):
+        for file_obj in files_stored:
+            if (file_obj.startswith(self.fix_subdirs)
+                    and file_obj not in self.files_seen):
                 filtered_files.append(file_obj)
+
+        self.files_seen = set(files_stored)
 
         return filtered_files
 

--- a/src/hidra/sender/eventdetectors/http_events.py
+++ b/src/hidra/sender/eventdetectors/http_events.py
@@ -64,6 +64,37 @@ __author__ = ('Manuela Kuhn <manuela.kuhn@desy.de>',
               'Jan Garrevoet <jan.garrevoet@desy.de>')
 
 
+class HTTPConnection:
+    def __init__(self, session):
+        self.session = session
+
+    def get_file_list(self, url):
+        response = self.session.get(url)
+        response.raise_for_status()
+        return response.json()
+
+
+class FileFilter:
+    def __init__(self, fix_subdirs, history_size):
+        self.fix_subdirs = tuple(fix_subdirs)
+        # history to prevent double events
+        self.files_seen = collections.deque(maxlen=history_size)
+
+    def get_new_files(self, files_stored):
+        new_files = []
+        if (not files_stored
+                or set(files_stored).issubset(self.files_seen)):
+            return []
+
+        for file_obj in files_stored:
+            if (file_obj.startswith(self.fix_subdirs)
+                    and file_obj not in self.files_seen):
+                self.files_seen.append(file_obj)
+                new_files.append(file_obj)
+
+        return new_files
+
+
 class EventDetector(EventDetectorBase):
     """
     Implements an event detector to get files from the Eiger detector or other
@@ -83,16 +114,6 @@ class EventDetector(EventDetectorBase):
         #   self.log_queue
         #   self.log
 
-        self.session = None
-        self.det_ip = None
-        self.det_api_version = None
-        self.file_writer_url = None
-        self.data_url = None
-
-        # time to sleep after detector returned emtpy file list
-        self.sleep_time = 0.5
-        self.files_downloaded = None
-
         self.required_params = ["det_ip",
                                 "det_api_version",
                                 "history_size",
@@ -101,24 +122,43 @@ class EventDetector(EventDetectorBase):
         # check that the required_params are set inside of module specific
         # config
         self.check_config()
-        self.setup()
 
-    def setup(self):
+        self.event_detector_impl = EventDetectorImpl(self.config, self.log)
+
+    def get_new_event(self):
+        """Implementation of the abstract method get_new_event.
         """
-        Sets static configuration parameters and sets up ring buffer.
+        return self.event_detector_impl.get_new_event()
+
+    def stop(self):
+        """Implementation of the abstract method stop.
         """
+        pass
 
-        self.session = requests.session()
 
+class EventDetectorImpl:
+    def __init__(self, config, log):
+        self.config = config
+        self.log = log
+
+        # time to sleep after detector returned emtpy file list
+        self.sleep_time = 0.5
         # Enable specification via IP and DNS name
-        self.det_ip = socket.gethostbyaddr(self.config["det_ip"])[2][0]
-        self.det_api_version = self.config["det_api_version"]
+        det_ip = socket.gethostbyaddr(self.config["det_ip"])[2][0]
+        self.file_writer_url = self._get_file_writer_url(det_ip)
+        self.data_url = self._get_data_url(det_ip)
 
+        self.connection = self._get_connection()
+
+        self.file_filter = self._get_file_filter()
+
+    def _get_file_writer_url(self, det_ip):
+        det_api_version = self.config["det_api_version"]
         try:
-            self.file_writer_url = (
+            file_writer_url = (
                 self.config["filewriter_url"]
-                .format(det_ip=self.det_ip,
-                        det_api_version=self.det_api_version)
+                .format(det_ip=det_ip,
+                        det_api_version=det_api_version)
             )
         except KeyError:
             if "det_api_version" not in self.config:
@@ -127,46 +167,57 @@ class EventDetector(EventDetectorBase):
                     "configured."
                 )
 
-            self.file_writer_url = ("http://{}/filewriter/api/{}/files/"
-                                    .format(self.det_ip, self.det_api_version))
+            file_writer_url = (
+                "http://{}/filewriter/api/{}/files/"
+                .format(det_ip, det_api_version))
 
-        self.log.debug("Getting files from: %s", self.file_writer_url)
+        self.log.debug("Getting files from: %s", file_writer_url)
+        return file_writer_url
 
+    def _get_connection(self):
+        session = requests.session()
+        return HTTPConnection(session)
+
+    def _get_data_url(self, det_ip):
         try:
-            self.data_url = self.config["datat_url"].format(det_ip=self.det_ip)
+            data_url = self.config["datat_url"].format(det_ip=det_ip)
         except KeyError:
-            self.data_url = "http://{}/data".format(self.det_ip)
+            data_url = "http://{}/data".format(det_ip)
 
-        # history to prevent double events
-        self.files_downloaded = collections.deque(
-            maxlen=self.config["history_size"]
-        )
+        return data_url
+
+    def _get_file_filter(self):
+        return FileFilter(
+            self.config["fix_subdirs"], self.config["history_size"])
 
     def get_new_event(self):
         """Implementation of the abstract method get_new_event.
         """
 
-        event_message_list = []
+        files_stored = self._get_files_stored()
+        if not files_stored:
+            # Wait till next try to prevent denial of service
+            time.sleep(self.sleep_time)
+            return []
 
+        new_files = self.file_filter.get_new_files(files_stored)
+
+        if not new_files:
+            # no new files received
+            time.sleep(self.sleep_time)
+            return []
+
+        event_message_list = self._build_event_messages(new_files)
+
+        return event_message_list
+
+    def _get_files_stored(self):
         try:
-            response = self.session.get(self.file_writer_url)
-        except KeyboardInterrupt:
-            return event_message_list
+            files_stored = self.connection.get_file_list(self.file_writer_url)
         except Exception:
             self.log.error("Error in getting file list from %s",
                            self.file_writer_url, exc_info=True)
-            # Wait till next try to prevent denial of service
-            time.sleep(self.sleep_time)
-            return event_message_list
-
-        try:
-            response.raise_for_status()
-            files_stored = response.json()
-        except Exception:
-            self.log.error("Getting file list...failed.", exc_info=True)
-            # Wait till next try to prevent denial of service
-            time.sleep(self.sleep_time)
-            return event_message_list
+            return []
 
         # api version 1.8.0 and newer return a dictionary instead of a list
         if isinstance(files_stored, dict):
@@ -176,28 +227,17 @@ class EventDetector(EventDetectorBase):
         if files_stored is None:
             files_stored = []
 
-        if (not files_stored
-                or set(files_stored).issubset(self.files_downloaded)):
-            # no new files received
-            time.sleep(self.sleep_time)
+        return files_stored
 
-        fix_subdirs_tuple = tuple(self.config["fix_subdirs"])
-        for file_obj in files_stored:
-            if (file_obj.startswith(fix_subdirs_tuple)
-                    and file_obj not in self.files_downloaded):
-                (relative_path, filename) = os.path.split(file_obj)
-                event_message = {
-                    "source_path": self.data_url,
-                    "relative_path": relative_path,
-                    "filename": filename
-                }
-                self.log.debug("event_message %s", event_message)
-                event_message_list.append(event_message)
-                self.files_downloaded.append(file_obj)
-
+    def _build_event_messages(self, new_files):
+        event_message_list = []
+        for file_obj in new_files:
+            (relative_path, filename) = os.path.split(file_obj)
+            event_message = {
+                "source_path": self.data_url,
+                "relative_path": relative_path,
+                "filename": filename
+            }
+            self.log.debug("event_message %s", event_message)
+            event_message_list.append(event_message)
         return event_message_list
-
-    def stop(self):
-        """Implementation of the abstract method stop.
-        """
-        pass

--- a/test/pytest/sender/eventdetectors/test_http_events.py
+++ b/test/pytest/sender/eventdetectors/test_http_events.py
@@ -1,0 +1,181 @@
+import logging
+from pathlib import Path
+from unittest.mock import create_autospec, patch
+import pytest
+import hidra  # noqa
+from eventdetectors.http_events import (
+    EventDetectorImpl, create_eventdetector_impl, HTTPConnection, FileFilter,
+    resolve_ip)
+
+fix_subdir = Path("current/raw")
+
+log = logging.getLogger(__name__)
+
+
+def test_resolve_ip():
+    ip = resolve_ip("127.0.0.1")
+    assert ip == "127.0.0.1"
+
+
+def test_resolve_ip_by_name():
+    ip = resolve_ip("localhost")
+    assert ip in ["127.0.0.1", "::1"]
+
+
+def test_create_eventdetector_imp_full_dict():
+    config = dict(
+        det_ip="127.0.0.1",
+        det_api_version="1.8.0",
+        history_size=2000,
+        fix_subdirs=["current/raw"],
+        file_writer_url="foo",
+        data_url="bar"
+    )
+    eventdetector = create_eventdetector_impl(**config, log=log)
+    assert eventdetector
+
+
+def test_create_eventdetector_imp_default_dict():
+    config = dict(
+        det_ip="127.0.0.1",
+        det_api_version="1.8.0",
+        history_size=2000,
+        fix_subdirs=["current/raw"],
+    )
+    eventdetector = create_eventdetector_impl(**config, log=log)
+    assert eventdetector
+
+
+@pytest.fixture
+def mock_sleep():
+    with patch("eventdetectors.http_events.time.sleep", autospec=True) as mock:
+        yield mock
+
+
+@pytest.fixture
+def connection():
+    mock = create_autospec(HTTPConnection)
+    mock.get_file_list.return_value = []
+    return mock
+
+
+@pytest.fixture
+def file_filter():
+    return FileFilter(["current/raw"], 10)
+
+
+@pytest.fixture
+def eventdetector(connection, file_filter):
+    return EventDetectorImpl(
+        "file_url", "data_url", connection, file_filter, log)
+
+
+def test_get_files_stored_empty(eventdetector):
+    files_stored = eventdetector._get_files_stored()
+    assert files_stored == []
+
+
+def test_get_files_stored(eventdetector, connection):
+    connection.get_file_list.return_value = ["filename"]
+    files_stored = eventdetector._get_files_stored()
+    assert files_stored == ["filename"]
+
+
+def test_get_files_stored_version_1_8_0_empty(eventdetector, connection):
+    connection.get_file_list.return_value = {"value": []}
+    files_stored = eventdetector._get_files_stored()
+    assert files_stored == []
+
+
+def test_get_files_stored_version_1_8_0_none(eventdetector, connection):
+    connection.get_file_list.return_value = {"value": None}
+    files_stored = eventdetector._get_files_stored()
+    assert files_stored == []
+
+
+def test_get_files_stored_version_1_8_0(eventdetector, connection):
+    connection.get_file_list.return_value = {"value": ["filename"]}
+    files_stored = eventdetector._get_files_stored()
+    assert files_stored == ["filename"]
+
+
+def test_get_files_stored_exception(eventdetector, connection):
+    connection.get_file_list.side_effect = ConnectionError
+    files_stored = eventdetector._get_files_stored()
+    assert files_stored == []
+
+
+def test_filter(file_filter):
+    files = ["current/raw/filename.ext"]
+    ret = file_filter.get_new_files(files)
+    assert ret == files
+
+
+def test_filter_multiple_files(file_filter):
+    files = ["current/raw/filename.ext", "current/raw/filename2.ext"]
+    ret = file_filter.get_new_files(files)
+    assert ret == files
+
+
+def test_filter_seen_files(file_filter):
+    files = ["current/raw/filename1.ext"]
+    ret = file_filter.get_new_files(files)
+    assert ret == files
+
+    files = ["current/raw/filename1.ext", "current/raw/filename2.ext"]
+    ret = file_filter.get_new_files(files)
+    assert ret == ["current/raw/filename2.ext"]
+
+    files = ["current/raw/filename2.ext", "current/raw/filename3.ext"]
+    ret = file_filter.get_new_files(files)
+    assert ret == ["current/raw/filename3.ext"]
+
+    files = [
+        "current/raw/filename1.ext", "current/raw/filename2.ext",
+        "current/raw/filename3.ext"]
+    ret = file_filter.get_new_files(files)
+    assert ret == []
+
+
+def test_filter_seen_history_size(file_filter):
+    files = []
+    for i in range(11):
+        filename = "current/raw/filename{}.ext".format(i)
+        files.append(filename)
+        ret = file_filter.get_new_files(files)
+        assert ret == [filename]
+
+    filename = "current/raw/filename11.ext"
+    files.append(filename)
+    ret = file_filter.get_new_files(files)
+    # ret now contains all files, which is a bug
+    pytest.skip()
+    assert ret == ["current/raw/filename0.ext", filename]
+
+
+def test_filter_not_in_subdir(file_filter):
+    files = ["other_dir/filename.ext"]
+    ret = file_filter.get_new_files(files)
+    assert ret == []
+
+
+def test_new_event_empty(eventdetector, mock_sleep):
+    new_events = eventdetector.get_new_event()
+    assert new_events == []
+    mock_sleep.assert_called_with(0.5)
+
+
+def test_new_event_exception(eventdetector, connection, mock_sleep):
+    connection.get_file_list.side_effect = ConnectionError
+    new_events = eventdetector.get_new_event()
+    assert new_events == []
+    mock_sleep.assert_called_with(0.5)
+
+
+def test_new_event_files(eventdetector, connection, mock_sleep):
+    connection.get_file_list.return_value = ["current/raw/filename.ext"]
+    new_events = eventdetector.get_new_event()
+    assert new_events == [{
+        'source_path': 'data_url', 'filename': 'filename.ext',
+        'relative_path': 'current/raw'}]
+    mock_sleep.assert_not_called()


### PR DESCRIPTION
The first part of the PR is a refactoring of the http event detector. The refactoring makes it easier to write proper unit tests, which are added in another commit.

The main change is an alternative implementation to the internal history deque. The most likely reason for the existence of this internal buffer is to avoid emitting multiple events for the same file, which would lead to multiple attempts to download it. However, this approach also prevents the user from reusing previous file names as long as they remain in the buffer, even if the file name has been used only during a different beamtime (which is especially likely for file names like `"test"`). The new implementation removes a file name from the buffer as soon as it was successfully downloaded and deleted from the server and thus disappears from the list of files returned by the http request.

As it cannot be excluded that the previous behavior is relied on by some users to prevent overwriting files by accident when creating files with already existing file names, the new implementation is only used if a negative `history_size` is configured (which previously was an error).

In case the old behavior is not needed, the `history_size` option could be removed completely.

There is still a small window of up to 0.5s in which a new file would be considered the same as a previous one with the same name. In such an unlikely case, the file will not be downloaded until the datamanager is restarted.