### PR TITLE
Switch to asapo 21.03

### DIFF
--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -185,6 +185,7 @@ class Plugin(object):
         """
 
         if self._config_is_modified() or self.asapo_worker is None:
+            self.config.update(utils.load_config(self.config["user_config_path"]))
             self.asapo_worker = AsapoWorker(self.config)
 
         self.asapo_worker.send_message(local_path, metadata)
@@ -206,9 +207,6 @@ class Plugin(object):
 
 class AsapoWorker:
     def __init__(self, config):
-        user_config = utils.load_config(config["user_config_path"])
-        config.update(user_config)
-
         self.endpoint = config["endpoint"]
         self.n_threads = config["n_threads"]
         self.timeout = config["timeout"]

--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -221,9 +221,10 @@ class Plugin(object):
 
 class AsapoWorker:
     def __init__(self, endpoint, beamtime, token, n_threads, file_regex,
-                 data_source=None, timeout=5):
+                 data_source=None, timeout=5, beamline='auto'):
         self.endpoint = endpoint
         self.beamtime = beamtime
+        self.beamline = beamline
         self.token = token
         self.n_threads = n_threads
         self.timeout = timeout
@@ -238,7 +239,7 @@ class AsapoWorker:
     def _create_producer(self, data_source):
         logger.info("Create producer with data_source=%s", data_source)
         self.data_source_info[data_source] = {
-            "producer": asapo_producer.create_producer(self.endpoint, "raw", self.beamtime, "auto",
+            "producer": asapo_producer.create_producer(self.endpoint, "raw", self.beamtime, self.beamline,
                                                        data_source, self.token, self.n_threads,
                                                        self.timeout * 1000),
         }

--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -78,11 +78,6 @@ except ImportError:
     from pathlib2 import Path
 
 
-def get_data(local_path):
-    with open(str(local_path), "rb") as f:
-        return f.read()
-
-
 def get_exposed_path(metadata):
     exposed_path = Path(metadata["relative_path"],
                         metadata["filename"]).parts
@@ -109,8 +104,6 @@ def get_entry(dict_obj, name):
 def get_ingest_mode(mode):
     if mode == "INGEST_MODE_TRANSFER_METADATA_ONLY":
         return asapo_producer.INGEST_MODE_TRANSFER_METADATA_ONLY
-    elif mode == "DEFAULT_INGEST_MODE":
-        return asapo_producer.DEFAULT_INGEST_MODE
     else:
         raise utils.NotSupported("Ingest mode '{}' is not supported"
                                  .format(mode))
@@ -257,17 +250,11 @@ class AsapoWorker:
 
         if data_source not in self.data_source_info:
             self._create_producer(data_source=data_source)
-
         producer = self.data_source_info[data_source]["producer"]
-
-        data = None
-        if self.ingest_mode != asapo_producer.INGEST_MODE_TRANSFER_METADATA_ONLY:
-            data = get_data(local_path)
-
         self.log.debug("using stream %s", stream)
         producer.send(id=file_idx + 1,  # files start with index 0 and asapo with 1
                       exposed_path=get_exposed_path(metadata),
-                      data=data,
+                      data=None,
                       user_meta=json.dumps({"hidra": metadata}),
                       ingest_mode=self.ingest_mode,
                       stream=stream,

--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -158,7 +158,7 @@ class Plugin(object):
         check_config(self.log, self.config, required_parameter)
 
         if "data_source" in self.config:
-            self.log.debug("Static data_source configured. Using: %s", self.data_source)
+            self.log.debug("Static data_source configured. Using: %s", self.config["data_source"])
 
         if "token" in self.config:
             self.log.debug("Static token configured.")
@@ -216,7 +216,7 @@ class AsapoWorker:
     def __init__(self, config):
         self.endpoint = config["endpoint"]
         self.n_threads = config["n_threads"]
-        self.timeout = config["timeout"]
+        self.timeout = config.get("timeout", 5)
         self.beamtime = config["beamtime"]
         self.token = config["token"]
         self.ingest_mode = get_ingest_mode(config["ingest_mode"])
@@ -224,13 +224,13 @@ class AsapoWorker:
         self.data_source = config.get("data_source", None)
         self.file_regex = config["file_regex"]
 
-        if "ignore_regex" in config:
-            self.ignore_regex = config["ignore_regex"]
-            self.log.debug("Ignoring files matching '%s'.", self.ignore_regex)
-
         self.lock = threading.Lock()
         self.log = logging.getLogger(__name__)
         self.data_source_info = {}
+
+        if "ignore_regex" in config:
+            self.ignore_regex = config["ignore_regex"]
+            self.log.debug("Ignoring files matching '%s'.", self.ignore_regex)
 
     def _create_producer(self, data_source):
         self.log.info("Create producer with data_source=%s", data_source)

--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -35,6 +35,7 @@ asapo_producer:
     n_threads: int
     file_regex: regex string
     user_config_path: : string # path to user config file
+    start_file_idx : Start file index, default 1
 
 Example config:
     asapo_producer:
@@ -159,7 +160,6 @@ class Plugin(object):
         ]
         check_config(self.config, required_parameter)
 
-
         if "token" in self.config:
             logger.debug("Static token configured.")
 
@@ -219,7 +219,7 @@ class Plugin(object):
 
 class AsapoWorker:
     def __init__(self, endpoint, beamtime, token, n_threads, file_regex,
-                 default_data_source=None, timeout=5, beamline='auto'):
+                 default_data_source=None, timeout=5, beamline='auto', start_file_idx=1):
         self.endpoint = endpoint
         self.beamtime = beamtime
         self.beamline = beamline
@@ -228,6 +228,7 @@ class AsapoWorker:
         self.timeout = timeout
         self.default_data_source = default_data_source
         self.file_regex = file_regex
+        self.start_file_idx = start_file_idx
 
         # Other ingest modes are not yet implemented
         self.ingest_mode = get_ingest_mode("INGEST_MODE_TRANSFER_METADATA_ONLY")
@@ -257,7 +258,7 @@ class AsapoWorker:
             return
 
         producer = self._get_producer(data_source)
-        producer.send(id=file_idx + 1,  # files start with index 0 and asapo with 1
+        producer.send(id=file_idx + 1 - self.start_file_idx,  # files start with index 0 and asapo with 1
                       exposed_path=get_exposed_path(metadata),
                       data=None,
                       user_meta=json.dumps({"hidra": metadata}),

--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -192,11 +192,11 @@ class Plugin(object):
     def _config_is_modified(self):
         ts = time()
         if (self.check_time - ts) > self.timeout:
-            self.check_time = ts
             file_path = self.config["user_config_path"]
             if self.config_time != path.getmtime(file_path):
                 self.config_time = path.getmtime(file_path)
                 return True
+        self.check_time = ts
         return False
 
     def stop(self):

--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -226,20 +226,11 @@ class AsapoWorker:
         self.data_source_info = {}
 
     def _create_producer(self, data_source):
-        config = dict(
-            endpoint=self.endpoint,
-            type="raw",
-            beamtime_id=self.beamtime,
-            beamline="auto",
-            data_source=data_source,
-            token=self.token,
-            nthreads=self.n_threads,
-            timeout_ms=self.timeout * 1000
-        )
-
-        self.log.info("Create producer with config=%s", config)
+        self.log.info("Create producer with data_source=%s", data_source)
         self.data_source_info[data_source] = {
-            "producer": asapo_producer.create_producer(**config),
+            "producer": asapo_producer.create_producer(self.endpoint, "raw", self.beamtime, "auto",
+                                                       data_source, self.token, self.n_threads,
+                                                       self.timeout * 1000),
         }
 
     def send_message(self, local_path, metadata):

--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -159,8 +159,6 @@ class Plugin(object):
         ]
         check_config(self.config, required_parameter)
 
-        if "data_source" in self.config:
-            logger.debug("Static data_source configured. Using: %s", self.config["data_source"])
 
         if "token" in self.config:
             logger.debug("Static token configured.")

--- a/test/pytest/receiver/plugins/test_asapo_receiver.py
+++ b/test/pytest/receiver/plugins/test_asapo_receiver.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+import sys
+import pytest
+from unittest.mock import create_autospec
+import asapo_producer
+
+receiver_path = (
+    Path(__file__).parent.parent.parent.parent.parent / "src/hidra/receiver")
+assert receiver_path.is_dir()
+sys.path.insert(0, receiver_path)
+
+from plugins.asapo_producer import Plugin  # noqa
+
+
+@pytest.fixture
+def plugin():
+    plugin = Plugin(dict(
+        endpoint="asapo-services:8400",
+        beamline="p00",
+        beamtime="auto",
+        token="abcdefg1234=",
+        data_source='test001',
+        n_threads=1,
+        ingest_mode="INGEST_MODE_TRANSFER_METADATA_ONLY",
+        file_regex=".*/(?P<detector>.*)/(?P<scan_id>.*)_scan[0-9]*-(?P<file_idx_in_scan>.*).tif",
+        ignore_regex=".*/.*.metadata$",
+    ))
+    plugin.send_message = create_autospec(plugin.send_message)
+    plugin._get_file_idx = create_autospec(plugin._get_file_idx, return_value=1)
+    yield plugin
+
+
+@pytest.fixture
+def plugin_sequential():
+    plugin = Plugin(dict(
+        endpoint="asapo-services:8400",
+        beamline="p00",
+        beamtime="auto",
+        token="abcdefg1234=",
+        data_source='test001',
+        n_threads=1,
+        ingest_mode="DEFAULT_INGEST_MODE",
+        file_regex=".*/(?P<detector>.*)/(?P<scan_id>.*)_scan[0-9]*-(?P<file_idx_in_scan>.*).tif",
+        ignore_regex=".*/.*.metadata$",
+        sequential_idx=True
+    ))
+    plugin.send_message = create_autospec(plugin.send_message)
+    plugin._get_file_idx = create_autospec(plugin._get_file_idx, return_value=1)
+    yield plugin
+
+
+@pytest.fixture
+def filepath():
+    return "/tmp/hidra_source/current/raw/det01/stream100_scan0-107.tif"
+
+
+@pytest.fixture
+def metadata(filepath):
+    return {'relative_path': 'current/stream100_scan0-107.tif',
+            'filename': 'stream100_scan0-107.tif'}
+
+
+def test_setup(plugin, metadata, filepath):
+    plugin.setup()
+    assert plugin.ingest_mode == asapo_producer.INGEST_MODE_TRANSFER_METADATA_ONLY
+
+    plugin.process(local_path=filepath, metadata=metadata)
+    _, local_path, file_idx, stream, send_meta = plugin.send_message.call_args[0]
+    assert local_path == filepath
+    assert file_idx == 107
+    assert stream == 'stream100'
+    assert send_meta == metadata
+
+
+def test_sequential(plugin_sequential, metadata, filepath):
+    plugin_sequential.setup()
+    assert plugin_sequential.ingest_mode == asapo_producer.DEFAULT_INGEST_MODE
+
+    plugin_sequential.process(local_path=filepath, metadata=metadata)
+    _, local_path, file_idx, stream, send_meta = plugin_sequential.send_message.call_args[0]
+    assert local_path == filepath
+    assert file_idx == 1
+    assert stream == 'stream100'
+    assert send_meta == metadata

--- a/test/pytest/receiver/plugins/test_asapo_receiver.py
+++ b/test/pytest/receiver/plugins/test_asapo_receiver.py
@@ -18,14 +18,11 @@ from plugins.asapo_producer import Plugin, AsapoWorker  # noqa
 def config():
     config = dict(
         endpoint="asapo-services:8400",
-        beamline="p00",
-        beamtime="auto",
+        beamtime="p00",
         token="abcdefg1234=",
         data_source='test001',
         n_threads=1,
-        ingest_mode="INGEST_MODE_TRANSFER_METADATA_ONLY",
         file_regex=".*/(?P<detector>.*)/(?P<scan_id>.*)_scan[0-9]*-(?P<file_idx_in_scan>.*).tif",
-        ignore_regex=".*/.*.metadata$",
         user_config_path="Path"
     )
     return config
@@ -33,7 +30,8 @@ def config():
 
 @pytest.fixture
 def worker(config):
-    worker = AsapoWorker(config)
+    config = {k: v for k, v in config.items() if k != "user_config_path"}
+    worker = AsapoWorker(**config)
     worker.send_message = create_autospec(worker.send_message)
     yield worker
 
@@ -70,6 +68,7 @@ def test_config_time(plugin, metadata):
         plugin.config_timeout = 1
         plugin._get_config_time("bla")
     except FileNotFoundError as err:
+        print("ERR: ", err)
         assert "No such file or directory" in str(err)
 
     file_path = Path(__file__)

--- a/test/pytest/receiver/plugins/test_asapo_receiver.py
+++ b/test/pytest/receiver/plugins/test_asapo_receiver.py
@@ -20,7 +20,7 @@ def config():
         endpoint="asapo-services:8400",
         beamtime="p00",
         token="abcdefg1234=",
-        data_source='test001',
+        default_data_source='test001',
         n_threads=1,
         file_regex=".*/(?P<detector>.*)/(?P<scan_id>.*)_scan[0-9]*-(?P<file_idx_in_scan>.*).tif",
         user_config_path="Path"

--- a/test/pytest/receiver/plugins/test_asapo_receiver.py
+++ b/test/pytest/receiver/plugins/test_asapo_receiver.py
@@ -30,8 +30,9 @@ def config():
 
 @pytest.fixture
 def worker(config):
-    del config["user_config_path"]
-    worker = AsapoWorker(**config)
+    worker_config = config.copy()
+    del worker_config["user_config_path"]
+    worker = AsapoWorker(**worker_config)
     worker.send_message = create_autospec(worker.send_message)
     yield worker
 
@@ -63,12 +64,7 @@ def test_worker(worker, metadata, filepath):
 
 def test_config_time(plugin, metadata):
     plugin.setup()
-    plugin.config_timeout = 1
-    try:
-        plugin._get_config_time("bla")
-    except FileNotFoundError as err:
-        with pytest.raises(FileNotFoundError, "No such file or directory"):
-            plugin._get_config_time("bla")
+    assert plugin._get_config_time("bla") == 0
 
     file_path = Path(__file__)
     conf_time = path.getmtime(file_path)


### PR DESCRIPTION
@schooft 

Asapo plugin is switched to new Asapo interface. I tested it with ASAPO 21.03.

Plugin implements following logic:
 - Asapo data-source, stream and message index can be extracted from the file path.
 - If data-source is given in the config it is considered to be fixed.
 - If flag: sequential_idx is True message index is not taken from file. Instead messages are getting sequential indices (1,2,3,...)
 - If ingest mode is "DEFAULT_INGEST_MODE" plugin will send a data buffer to asapo.