### PR TITLE
Execute plugins in a separate thread

### DIFF
--- a/src/hidra/receiver/datareceiver.py
+++ b/src/hidra/receiver/datareceiver.py
@@ -37,6 +37,7 @@ import copy
 from importlib import import_module
 import logging
 import os
+import queue
 import signal
 import threading
 import time
@@ -259,6 +260,97 @@ class CheckNetgroup(threading.Thread):
         self.run_loop = False
 
 
+def run_plugin_thread(
+        plugin_name, plugin_config, target_dir, data_queue, log, event):
+    # Execute all plugin code on a separate thread to protect main thread from
+    # slow or blocking plugins
+    try:
+        plugin_m = import_module("plugins." + plugin_name)
+        plugin = plugin_m.Plugin(plugin_config)
+        plugin.setup()
+        log.info("Loading '%s' plugin", plugin_name)
+    except Exception:
+        log.error("Could not load '%s' plugin", plugin_name, exc_info=True)
+        return
+
+    while not event.is_set():
+        try:
+            data = data_queue.get(timeout=0.5)
+        except queue.Empty:
+            continue
+
+        try:
+            [metadata, data] = data
+            plugin.process(
+                local_path=generate_filepath(target_dir, metadata),
+                metadata=metadata,
+                data=data
+            )
+        except Exception:
+            log.error("Processing data with '%s' plugin failed.",
+                      plugin_name, exc_info=True)
+
+        data_queue.task_done()
+
+    try:
+        plugin.stop()
+    except Exception:
+        log.error(
+            "Error while stopping '%s' plugin", plugin_name, exc_info=True)
+
+
+class PluginHandler:
+    def __init__(self, plugin_name, plugin_config, target_dir, log):
+        self.plugin_name = plugin_name
+        self.plugin_config = plugin_config
+        self.log = log
+
+        self.plugin_queue = queue.Queue()
+        self.plugin_event = threading.Event()
+        self.plugin_thread = threading.Thread(
+            target=run_plugin_thread,
+            args=(self.plugin_name, self.plugin_config, target_dir,
+                  self.plugin_queue, self.log, self.plugin_event),
+            daemon=True)  # stop process even if thread is still alive
+
+    def get_data_type(self):
+        return self.plugin_config.get("plugin_type", "metadata")
+
+    def start(self):
+        self.log.info("Starting '%s' plugin thread", self.plugin_name)
+        self.plugin_thread.start()
+
+    def put(self, message):
+        if self.plugin_queue.qsize() < 10000:
+            self.plugin_queue.put(message)
+        else:
+            self.log.warning(
+                "Skipping '%s' plugin because queue is full", self.plugin_name)
+
+    def stop(self, timeout=60):
+        self.log.info(
+            "Waiting for '%s' plugin thread to finish", self.plugin_name)
+
+        # wait manually because queue.join doesn't have a timeout parameter
+        while self.plugin_queue.qsize() > 0 and timeout > 0:
+            time.sleep(0.1)
+            timeout -= 0.1
+
+        if timeout <= 0:
+            self.log.error(
+                "'%s' plugin queue not empty after timeout", self.plugin_name)
+            timeout = 1  # always give the thread a second to join
+
+        self.plugin_event.set()
+
+        if self.plugin_thread:
+            self.plugin_thread.join(timeout=timeout)
+
+        if self.plugin_thread.is_alive():
+            self.log.error(
+                "'%s' plugin did not join within timeout", self.plugin_name)
+
+
 class DataReceiver(object):
     """Receives data and stores it to disc usign the hidra API.
     """
@@ -280,8 +372,7 @@ class DataReceiver(object):
         self.transfer = None
         self.checking_thread = None
 
-        self.plugin_config = None
-        self.plugin = None
+        self.plugin_handler = None
 
         self.run_loop = True
 
@@ -406,20 +497,13 @@ class DataReceiver(object):
     def _load_plugin(self):
         try:
             plugin_name = self.config["datareceiver"]["plugin"]
-            self.plugin_config = self.config[plugin_name]
+            plugin_config = self.config[plugin_name]
         except KeyError:
             self.log.debug("No plugin specified")
-            self.plugin_config = {}
             return
 
-        try:
-            plugin_m = import_module("plugins." + plugin_name)
-            self.plugin = plugin_m.Plugin(self.plugin_config)
-            self.plugin.setup()
-            self.log.info("Loading plugin %s", plugin_name)
-        except Exception:
-            self.log.error("Could not load plugin", exc_info=True)
-            self.plugin = None
+        self.plugin_handler = PluginHandler(
+            plugin_name, plugin_config, self.target_dir, self.log)
 
     def exec_run(self):
         """Wrapper around run to react to exceptions.
@@ -443,8 +527,9 @@ class DataReceiver(object):
         global _whitelist  # pylint: disable=global-variable-not-assigned
         global _changed_netgroup
 
-        if self.plugin is not None:
-            plugin_type = self.plugin.get_data_type()
+        if self.plugin_handler is not None:
+            plugin_type = self.plugin_handler.get_data_type()
+            self.plugin_handler.start()
         else:
             plugin_type = None
 
@@ -486,20 +571,13 @@ class DataReceiver(object):
                 self.log.error("Storing data...failed.", exc_info=True)
                 raise
 
-            if self.plugin is None or ret_val is None:
+            if self.plugin_handler is None or ret_val is None:
                 continue
 
             try:
-                [metadata, data] = ret_val
-
-                self.plugin.process(
-                    local_path=generate_filepath(self.target_dir, metadata),
-                    metadata=metadata,
-                    data=data
-                )
+                self.plugin_handler.put(ret_val)
             except Exception:
-                self.log.error("Processing data with plugin failed.",
-                               exc_info=True)
+                self.log.error("Cannot submit message to plugin")
 
     def stop(self, store=True):
         """Stop threads, close sockets and cleans up.
@@ -531,8 +609,8 @@ class DataReceiver(object):
             self.transfer.stop()
             self.transfer = None
 
-        if self.plugin is not None:
-            self.plugin.stop()
+        if self.plugin_handler is not None:
+            self.plugin_handler.stop()
 
         if self.checking_thread is not None:
             self.checking_thread.stop()

--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -166,9 +166,6 @@ class Plugin(object):
         if "token" in self.config:
             logger.debug("Static token configured.")
 
-    def get_data_type(self):
-        return "metadata"
-
     def process(self, local_path, metadata, data=None):
         """Send the file to the ASAP::O producer
 

--- a/test/pytest/receiver/test_receiver.py
+++ b/test/pytest/receiver/test_receiver.py
@@ -1,0 +1,151 @@
+import logging
+from pathlib import Path
+import sys
+import time
+import pytest
+
+receiver_path = (
+    Path(__file__).parent.parent.parent.parent / "src/hidra/receiver")
+assert receiver_path.is_dir()
+sys.path.insert(0, receiver_path)
+
+from datareceiver import PluginHandler, run_plugin_thread  # noqa
+import plugins.mock_plugin as mock_plugin_m  # noqa
+
+log = logging.getLogger(__name__)
+
+metadata = {
+    "relative_path": "relative_path",
+    "filename": "filename"}
+
+
+@pytest.fixture
+def mock_plugin():
+    mock_plugin_m.Plugin.side_effect = None
+    mock_plugin = mock_plugin_m.Plugin(None)
+    mock_plugin_m.Plugin.reset_mock()
+    mock_plugin.reset_mock()
+    mock_plugin.setup.side_effect = None
+    mock_plugin.process.side_effect = None
+    mock_plugin.stop.side_effect = None
+    return mock_plugin
+
+
+def test_plugin_start_stop(mock_plugin):
+    plugin_handler = PluginHandler("mock_plugin", {"foo": 1}, "bar", log)
+    plugin_handler.start()
+    plugin_handler.stop()
+    mock_plugin_m.Plugin.assert_called_once_with({"foo": 1})
+    mock_plugin = mock_plugin_m.Plugin(None)
+    mock_plugin.setup.assert_called_once_with()
+    mock_plugin.stop.assert_called_once_with()
+    mock_plugin.process.assert_not_called()
+
+
+def test_plugin_put(mock_plugin):
+    plugin_handler = PluginHandler("mock_plugin", {"foo": 1}, "bar", log)
+    plugin_handler.start()
+    plugin_handler.put((metadata, 1))
+    plugin_handler.stop()
+    mock_plugin.process.assert_called_once_with(
+        local_path="bar/relative_path/filename",
+        metadata=metadata,
+        data=1)
+
+
+def test_plugin_fail_init(mock_plugin, caplog):
+    plugin_handler = PluginHandler("mock_plugin", {"foo": 1}, "bar", log)
+    mock_plugin_m.Plugin.side_effect = Exception()
+    plugin_handler.start()
+    plugin_handler.put((metadata, 1))
+    plugin_handler.stop(0)
+    mock_plugin.process.assert_not_called()
+    assert "ERROR" in caplog.text
+
+
+def test_plugin_fail_setup(mock_plugin, caplog):
+    plugin_handler = PluginHandler("mock_plugin", {"foo": 1}, "bar", log)
+    mock_plugin.setup.side_effect = Exception()
+    plugin_handler.start()
+    plugin_handler.put((metadata, 1))
+    plugin_handler.stop(0)
+    mock_plugin.process.assert_not_called()
+    assert "ERROR" in caplog.text
+
+
+def test_plugin_fail_process(mock_plugin, caplog):
+    plugin_handler = PluginHandler("mock_plugin", {"foo": 1}, "bar", log)
+    mock_plugin.process.side_effect = Exception()
+    plugin_handler.start()
+    plugin_handler.put((metadata, 1))
+    plugin_handler.stop()
+    mock_plugin.stop.assert_called_once_with()
+    assert "ERROR" in caplog.text
+
+
+def test_plugin_fail_stop(mock_plugin, caplog):
+    plugin_handler = PluginHandler("mock_plugin", {"foo": 1}, "bar", log)
+    mock_plugin.stop.side_effect = Exception()
+    plugin_handler.start()
+    plugin_handler.put((metadata, 1))
+    plugin_handler.stop()
+    assert "ERROR" in caplog.text
+
+
+def test_plugin_slow_init(mock_plugin, caplog):
+    plugin_handler = PluginHandler("mock_plugin", {"foo": 1}, "bar", log)
+    mock_plugin_m.Plugin.side_effect = lambda *args, **kwargs: time.sleep(100)
+    t0 = time.time()
+    plugin_handler.start()
+    plugin_handler.put((metadata, 1))
+    plugin_handler.stop(0)
+    mock_plugin.process.assert_not_called()
+    assert time.time() - t0 < 10
+    assert "timeout" in caplog.text
+
+
+def test_plugin_slow_setup(mock_plugin, caplog):
+    plugin_handler = PluginHandler("mock_plugin", {"foo": 1}, "bar", log)
+    mock_plugin.setup.side_effect = lambda *args, **kwargs: time.sleep(100)
+    t0 = time.time()
+    plugin_handler.start()
+    plugin_handler.put((metadata, 1))
+    plugin_handler.stop(0)
+    mock_plugin.process.assert_not_called()
+    assert time.time() - t0 < 10
+    assert "timeout" in caplog.text
+
+
+def test_plugin_slow_process(mock_plugin, caplog):
+    plugin_handler = PluginHandler("mock_plugin", {"foo": 1}, "bar", log)
+    mock_plugin.process.side_effect = lambda *args, **kwargs: time.sleep(100)
+    t0 = time.time()
+    plugin_handler.start()
+    plugin_handler.put((metadata, 1))
+    plugin_handler.stop(0)
+    assert time.time() - t0 < 10
+    assert "timeout" in caplog.text
+
+
+def test_plugin_slow_stop(mock_plugin, caplog):
+    plugin_handler = PluginHandler("mock_plugin", {"foo": 1}, "bar", log)
+    mock_plugin.stop.side_effect = lambda *args, **kwargs: time.sleep(100)
+    t0 = time.time()
+    plugin_handler.start()
+    plugin_handler.put((metadata, 1))
+    plugin_handler.stop(0)
+    assert time.time() - t0 < 10
+    assert "timeout" in caplog.text
+
+
+def test_plugin_queue_overlow(mock_plugin, caplog):
+    plugin_handler = PluginHandler("mock_plugin", {"foo": 1}, "bar", log)
+    mock_plugin.process.side_effect = lambda *args, **kwargs: time.sleep(100)
+    t0 = time.time()
+    plugin_handler.start()
+    for i in range(10005):
+        plugin_handler.put((metadata, 1))
+    plugin_handler.stop(0)
+    assert time.time() - t0 < 10
+    assert plugin_handler.plugin_queue.qsize() == 10000
+    assert "Skipping" in caplog.text

--- a/test/pytest/receiver/test_receiver.py
+++ b/test/pytest/receiver/test_receiver.py
@@ -139,6 +139,10 @@ def test_plugin_slow_stop(mock_plugin, caplog):
 
 
 def test_plugin_queue_overlow(mock_plugin, caplog):
+    """
+    The queue size limit is not exceeded and put doesn't block when the limit
+    is reached
+    """
     plugin_handler = PluginHandler("mock_plugin", {"foo": 1}, "bar", log)
     mock_plugin.process.side_effect = lambda *args, **kwargs: time.sleep(100)
     t0 = time.time()


### PR DESCRIPTION
Slow, blocking or failing plugins can negatively influence data storing.

By moving all plugin code to a separate daemon thread, the main thread
is protected from misbehaving plugins.

To enable this, the data type is changed to a configuration option.