### PR TITLE
Remove unnecessary lock from asapo callback

### DIFF
--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -277,13 +277,11 @@ class AsapoWorker:
             callback=self._callback)
 
     def _callback(self, header, err):
-        self.lock.acquire()
         header = {key: val for key, val in header.items() if key != 'data'}
         if err is None:
             logger.debug("Successfully sent: %s", header)
         else:
             logger.error("Could not sent: %s, %s", header, err)
-        self.lock.release()
 
     def _parse_file_name(self, path):
         matched = parse_file_path(self.file_regex, path)


### PR DESCRIPTION
The lock within the callback seems to be unnecessary. `Logger` uses its own lock internally and no other non-local variables are used.