### PR TITLE
Fix assertion error in unittests due to Thread mock

### DIFF
--- a/test/unittests/receiver/test_datareceiver.py
+++ b/test/unittests/receiver/test_datareceiver.py
@@ -60,8 +60,7 @@ class TestCheckNetgroup(TestBase):
         super().setUp()
 
     @mock.patch("hidra.utils.execute_ldapsearch")
-    @mock.patch("threading.Thread")
-    def test_check_netgroup(self, mock_thread, mock_ldap):
+    def test_check_netgroup(self, mock_ldap):
         """Simulate netgroup changes.
         """
         # pylint: disable=unused-argument


### PR DESCRIPTION
On Python 3.9 mocking Thread seems to fail. Tests pass after removing the mock. It is unclear why Thread was mocked in the first place.
