### PR TITLE
Refactor error propagation for regexp in asapo producer

### DIFF
--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -319,10 +319,7 @@ class AsapoWorker:
             data_source = self.default_data_source
 
         stream = get_entry(matched, "scan_id")
-        try:
-            file_idx = int(get_entry(matched, "file_idx_in_scan"))
-        except ValueError:
-            raise ValueError("Can not extract values from path %s", path)
+        file_idx = int(get_entry(matched, "file_idx_in_scan"))
         return data_source, stream, file_idx
 
     def stop(self):

--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -321,7 +321,7 @@ class AsapoWorker:
         stream = get_entry(matched, "scan_id")
         try:
             file_idx = int(get_entry(matched, "file_idx_in_scan"))
-        except Exception as e:
+        except ValueError:
             raise ValueError("Can not extract values from path %s", path)
         return data_source, stream, file_idx
 


### PR DESCRIPTION
@schooft 

Regexp for Asapo producer is compiled and presence of expected groups is checked in the contractor of the class.