### PR TITLE
Fix stopping old instances of previous beamline

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,11 @@ services:
         platform: linux
         container_name: ldap
         domainname: hidra.test
+        environment:
+            # Don't use quotes (single or double) for env values:
+            # https://github.com/osixia/docker-openldap/issues/479
+            - LDAP_BASE_DN=dc=hidra,dc=test
+            - LDAP_DOMAIN=hidra.test
         networks:
             hidra:
                 aliases:
@@ -29,6 +34,9 @@ services:
             - "5680:5680"
         depends_on:
             - ldap
+        cap_add:
+            # allow attaching a debugger inside the container
+            - SYS_PTRACE
         tty: true
 
     eiger:

--- a/src/hidra/hidra_control/server.py
+++ b/src/hidra/hidra_control/server.py
@@ -1137,6 +1137,9 @@ class ControlServer(utils.Base):
 
     def _decode_message(self, msg):
         """Decode the message
+
+        The action part is not decoded and instead the original bytes are
+        returned.
         """
 
         try:
@@ -1186,9 +1189,9 @@ class ControlServer(utils.Base):
     def exec_msg(self, msg):
         """
         [b"IS_ALIVE"]
-            return "OK"
+            return b"OK"
         [b"do", host_id, det_id, b"start"]
-            return "DONE"
+            return b"DONE"
         [b"bye", host_id, detector]
         """
 
@@ -1220,10 +1223,10 @@ class ControlServer(utils.Base):
             return self.reply_codes.error
 
         # bypass detector checking for this
-        if action == "do" and param == "get_instances":
+        if action == b"do" and param == "get_instances":
             # allow the beamline to see it's running instances
-            return self._get_instances()
-        elif action == "do" and param == "stop":
+            return json.dumps(self._get_instances()).encode()
+        elif action == b"do" and param == "stop":
             # allow the beamline to stop it's old instances
             if det_id in self._get_instances():
                 return self._stop_old_instance(det_id)
@@ -1303,7 +1306,7 @@ class ControlServer(utils.Base):
         """Get the started hidra instances
 
         Returns:
-            List of detectors started for this beamline as json dump.
+            List of detectors started for this beamline.
         """
 
         try:
@@ -1312,7 +1315,8 @@ class ControlServer(utils.Base):
             # something went wrong when trying to start the instance
             bl_instances = {}
 
-        instances = json.dumps(list(bl_instances.keys())).encode()
+        instances = list(bl_instances.keys())
+
         self.log.debug("Running instances are: %s", instances)
 
         return instances

--- a/test/docker/ldap/Dockerfile
+++ b/test/docker/ldap/Dockerfile
@@ -2,3 +2,6 @@
 FROM osixia/openldap:1.4.0
 
 COPY netgroup.ldif /container/service/slapd/assets/config/bootstrap/ldif/custom/
+COPY remove_all.ldif remove_all.ldif
+COPY remove_eiger.ldif remove_eiger.ldif
+COPY add_all.ldif add_all.ldif

--- a/test/docker/ldap/add_all.ldif
+++ b/test/docker/ldap/add_all.ldif
@@ -1,0 +1,11 @@
+dn: cn=a3p00-hosts,ou=netgroup,o=hidra
+changetype: modify
+replace: nisNetgroupTriple
+nisNetgroupTriple: (sender-freeze.hidra.test,-,)
+nisNetgroupTriple: (sender-debian.hidra.test,-,)
+nisNetgroupTriple: (sender-debian10.hidra.test,-,)
+nisNetgroupTriple: (sender-debian11.hidra.test,-,)
+nisNetgroupTriple: (sender-suse.hidra.test,-,)
+nisNetgroupTriple: (eiger.hidra.test,-,)
+nisNetgroupTriple: (control-client.hidra.test,-,)
+nisNetgroupTriple: (transfer-client.hidra.test,-,)

--- a/test/docker/ldap/netgroup.ldif
+++ b/test/docker/ldap/netgroup.ldif
@@ -1,10 +1,4 @@
-dn: olcDatabase={-1}frontend,cn=config
-changetype: modify
-delete: olcAccess
--
-add: olcAccess
-olcAccess: to * by * manage
-
+# Remove ACLs
 dn: olcDatabase={1}mdb,cn=config
 changetype: modify
 delete: olcAccess
@@ -12,6 +6,7 @@ delete: olcAccess
 add: olcAccess
 olcAccess: to * by * manage
 
+# Route queries without suffix to this database
 dn: olcDatabase={1}mdb,cn=config
 changetype: modify
 delete: olcSuffix
@@ -19,6 +14,7 @@ delete: olcSuffix
 add: olcSuffix
 olcSuffix:
 
+# Add entries
 dn: o=hidra
 changetype: add
 objectClass: organization

--- a/test/docker/ldap/remove_all.ldif
+++ b/test/docker/ldap/remove_all.ldif
@@ -1,0 +1,4 @@
+dn: cn=a3p00-hosts,ou=netgroup,o=hidra
+changetype: modify
+replace: nisNetgroupTriple
+nisNetgroupTriple: (foo.test,-,)

--- a/test/docker/ldap/remove_eiger.ldif
+++ b/test/docker/ldap/remove_eiger.ldif
@@ -1,0 +1,10 @@
+dn: cn=a3p00-hosts,ou=netgroup,o=hidra
+changetype: modify
+replace: nisNetgroupTriple
+nisNetgroupTriple: (sender-freeze.hidra.test,-,)
+nisNetgroupTriple: (sender-debian.hidra.test,-,)
+nisNetgroupTriple: (sender-debian10.hidra.test,-,)
+nisNetgroupTriple: (sender-debian11.hidra.test,-,)
+nisNetgroupTriple: (sender-suse.hidra.test,-,)
+nisNetgroupTriple: (control-client.hidra.test,-,)
+nisNetgroupTriple: (transfer-client.hidra.test,-,)


### PR DESCRIPTION
The Python 2 to 3 transition broke the functionality that allowed beamlines to stop their Hidra instances via the control client even after the detectors moved to other beamlines. This PR restores this functionality and adds tests to prevent future regressions.