### PR TITLE
Do not modify python path in unit tests

### DIFF
--- a/test/pytest/hidra_control/test_server.py
+++ b/test/pytest/hidra_control/test_server.py
@@ -4,13 +4,6 @@ import sys
 import yaml
 from unittest.mock import patch
 
-root_path = Path(__file__).parent.parent.parent.parent
-
-hidra_control_path = root_path / "src/hidra/hidra_control"
-default_config_path = root_path / "conf/control_server.yaml"
-assert hidra_control_path.is_dir()
-sys.path.insert(0, hidra_control_path)
-
 from server import argument_parsing  # noqa
 
 

--- a/test/pytest/receiver/plugins/test_asapo_producer.py
+++ b/test/pytest/receiver/plugins/test_asapo_producer.py
@@ -6,11 +6,6 @@ from time import time
 from unittest.mock import create_autospec, patch
 import asapo_producer
 
-receiver_path = (
-        Path(__file__).parent.parent.parent.parent.parent / "src/hidra/receiver")
-assert receiver_path.is_dir()
-sys.path.insert(0, receiver_path)
-
 from plugins.asapo_producer import Plugin, AsapoWorker  # noqa
 
 

--- a/test/pytest/receiver/test_receiver.py
+++ b/test/pytest/receiver/test_receiver.py
@@ -4,11 +4,6 @@ import sys
 import time
 import pytest
 
-receiver_path = (
-    Path(__file__).parent.parent.parent.parent / "src/hidra/receiver")
-assert receiver_path.is_dir()
-sys.path.insert(0, receiver_path)
-
 from datareceiver import PluginHandler, run_plugin_thread  # noqa
 import plugins.mock_plugin as mock_plugin_m  # noqa
 


### PR DESCRIPTION
Modifying the python path breaks test discovery in vscode. As not all unit tests manipulated the python path, setting it via the environment variable was necessary anyway.