### PR TITLE
Add message index offset via capture group in asapo plugin

### DIFF
--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -46,7 +46,7 @@ Example config:
         n_threads: 1
         user_config_path: 'path/to/conf'
         file_regex: '.*/(?P<data_source>.*)/scan_(?P<scan_id>.*)/'
-                    '(?P<file_idx_in_scan>.*).tif'
+                    '(?P<file_idx_offset>[0-9]+)-(?P<file_idx_in_scan>[0-9]+).tif'
 """
 
 from __future__ import absolute_import
@@ -168,8 +168,18 @@ class Plugin(object):
     def process(self, local_path, metadata, data=None):
         """Send the file to the ASAP::O producer
 
-        Asapo data_source and index are chosen by the incoming files in format
-        (<scan_id, <file_id>) -> (stream, id)
+        Asapo data_source, stream_name, and message ID are extracted from the local_path
+        via the configured file_regex. The file_regex must contain the following named
+        capture groups: scan_id, and file_idx_in_scan.
+
+        If data_source is not given by the regex, the configured default_data_source
+        will be used instead.
+
+        The message id is adjusted by the configured start_file_idx to reflect that
+        asapo message ids must start at 1 while the file_idx_in_scan can start at 0.
+
+        Additionally, if present, the file_idx_offset will be added to the
+        file_idx_in_scan to obtain the final message id.
 
         Args:
             local_path: The absolute path where the file was written

--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -313,6 +313,7 @@ class AsapoWorker:
         matched = parse_file_path(self.file_regex, path)
         if matched is None:
             return None
+
         if "data_source" in matched:
             data_source = get_entry(matched, "data_source")
         else:
@@ -320,6 +321,10 @@ class AsapoWorker:
 
         stream = get_entry(matched, "scan_id")
         file_idx = int(get_entry(matched, "file_idx_in_scan"))
+
+        if "file_idx_offset" in matched:
+            file_idx += int(get_entry(matched, "file_idx_offset"))
+
         return data_source, stream, file_idx
 
     def stop(self):

--- a/test/pytest/receiver/plugins/test_asapo_producer.py
+++ b/test/pytest/receiver/plugins/test_asapo_producer.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-import sys
+import json
 import pytest
 from os import path
 from time import time
@@ -17,10 +17,25 @@ def config():
         token="abcdefg1234=",
         default_data_source='test001',
         n_threads=1,
-        file_regex=".*/(?P<detector>.*)/(?P<scan_id>.*)_scan[0-9]*-(?P<file_idx_in_scan>.*).tif",
+        file_regex=(
+            ".*/(?P<detector>.*)/(?P<scan_id>.*)"
+            "_scan[0-9]*-(?P<file_idx_in_scan>.*).tif"
+        ),
         user_config_path="/path/to/config.yaml"
     )
     return config
+
+
+@pytest.fixture
+def mock_create_producer(monkeypatch):
+    mock = create_autospec(asapo_producer.create_producer)
+    monkeypatch.setattr(asapo_producer, "create_producer", mock)
+    return mock
+
+
+@pytest.fixture
+def mock_producer(mock_create_producer):
+    return mock_create_producer.return_value
 
 
 @pytest.fixture
@@ -28,8 +43,8 @@ def worker(config):
     worker_config = config.copy()
     del worker_config["user_config_path"]
     worker = AsapoWorker(**worker_config)
-    worker.send_message = create_autospec(worker.send_message)
-    yield worker
+    # worker.send_message = create_autospec(worker.send_message)
+    return worker
 
 
 @pytest.fixture
@@ -38,26 +53,94 @@ def plugin(config):
     yield plugin
 
 
-@pytest.fixture
-def filepath():
-    return "/tmp/hidra_source/current/raw/det01/stream100_scan0-107.tif"
+def test_worker_create_producer(worker, mock_create_producer, config):
+    filepath = "/tmp/hidra_source/current/raw/det01/stream100_scan0-107.tif"
+    metadata = {
+        "relative_path": "current/raw/det01",
+        "filename": "stream100_scan0-107.tif"
+    }
+    worker.send_message(filepath, metadata)
+
+    mock_create_producer.assert_called_once_with(
+        config["endpoint"],
+        'raw',
+        config["beamtime"],
+        config.get("beamline", "auto"),
+        config["default_data_source"],
+        config["token"],
+        config["n_threads"],
+        config.get("timeout", 5) * 1000,
+    )
 
 
-@pytest.fixture
-def metadata(filepath):
-    return {'relative_path': 'current/stream100_scan0-107.tif',
-            'filename': 'stream100_scan0-107.tif'}
+def test_worker_send_message(worker, mock_producer):
+    filepath = "/tmp/hidra_source/current/raw/det01/stream100_scan0-107.tif"
+    metadata = {
+        "relative_path": "current/raw/det01",
+        "filename": "stream100_scan0-107.tif"
+    }
+    worker.send_message(filepath, metadata)
+
+    mock_producer.send.assert_called_once()
+    args, kwargs = mock_producer.send.call_args
+    assert args == ()
+    assert kwargs["id"] == 107
+    assert kwargs["exposed_path"] == "raw/det01/stream100_scan0-107.tif"
+    assert kwargs["data"] is None
+    assert kwargs["ingest_mode"] == (
+        asapo_producer.INGEST_MODE_TRANSFER_METADATA_ONLY
+    )
+    assert kwargs["stream"] == "stream100"
+    assert kwargs["callback"] is not None
+    user_meta = json.loads(kwargs["user_meta"])
+    assert user_meta["hidra"] == metadata
 
 
-def test_worker(worker, metadata, filepath):
-    assert worker.ingest_mode == asapo_producer.INGEST_MODE_TRANSFER_METADATA_ONLY
-    data_source, stream, file_idx = worker._parse_file_name(filepath)
-    assert file_idx == 107
-    assert stream == 'stream100'
-    assert data_source == 'test001'
+def test_worker_non_matching_file(worker, mock_create_producer):
+    filepath = "/tmp/hidra_source/current/raw/det01/scan0-107.tif"
+    metadata = {
+        "relative_path": "current/raw/det01",
+        "filename": "scan0-107.tif"
+    }
+    worker.send_message(filepath, metadata)
+
+    mock_create_producer.assert_not_called()
 
 
-def test_config_time(plugin, metadata):
+def test_worker_stop(worker, mock_producer):
+    filepath = "/tmp/hidra_source/current/raw/det01/stream100_scan0-107.tif"
+    metadata = {
+        "relative_path": "current/raw/det01",
+        "filename": "stream100_scan0-107.tif"
+    }
+    worker.send_message(filepath, metadata)
+    worker.stop()
+    mock_producer.wait_requests_finished.assert_called_once()
+
+
+def test_worker_stop_no_producer(worker):
+    worker.stop()
+
+
+def test_worker_data_source_regex(config, mock_create_producer):
+    del config["user_config_path"]
+    config["file_regex"] = (
+        ".*/(?P<data_source>.*)/(?P<scan_id>.*)"
+        "_scan[0-9]*-(?P<file_idx_in_scan>.*).tif"
+    )
+    worker = AsapoWorker(**config)
+
+    filepath = "/tmp/hidra_source/current/raw/det01/stream100_scan0-107.tif"
+    metadata = {
+        "relative_path": "current/raw/det01",
+        "filename": "stream100_scan0-107.tif"
+    }
+    worker.send_message(filepath, metadata)
+
+    assert "det01" in mock_create_producer.call_args.args
+
+
+def test_config_time(plugin):
     plugin.setup()
     assert plugin._get_config_time("bla") == 0
 
@@ -67,7 +150,8 @@ def test_config_time(plugin, metadata):
 
 
 def test_config_modified(plugin):
-    plugin._get_config_time = create_autospec(plugin._get_config_time, return_value=100)
+    plugin._get_config_time = create_autospec(
+        plugin._get_config_time, return_value=100)
 
     plugin.check_time = 0
     assert plugin._config_is_modified()
@@ -78,7 +162,7 @@ def test_config_modified(plugin):
 
 
 def test_plugin_stop(plugin):
-    with patch("plugins.asapo_producer.AsapoWorker", autospec=True) as mock:
+    with patch("plugins.asapo_producer.AsapoWorker", autospec=True):
         plugin.process(None, None, None)  # will create a worker
         assert plugin.asapo_worker is not None
         plugin.stop()


### PR DESCRIPTION
Sometimes it is not possible to have a unique message index in the file
name. For these cases, a regex capture group named `file_idx_offset` can
be used. If the group is present in the regex, its value will be added
to the value of the `file_idx_in_scan` capture group to obtain the actual
message id for the asapo stream.