### PR TITLE
Add timeout to ldap search

### DIFF
--- a/src/api/python/hidra/utils/utils_network.py
+++ b/src/api/python/hidra/utils/utils_network.py
@@ -146,7 +146,10 @@ def _parse_ldap3(ldapuri, ldap_cn, log):
         server = ldap3.Server(ldapuri)
     else:
         server = [ldap3.Server(uri) for uri in ldapuri]
-    con = ldap3.Connection(server)
+    # receive_timeout=10 raises LDAPSocketReceiveError if blocked in open or search
+    # for more than 10 seconds
+    # can be tested with "docker-compose pause ldap"
+    con = ldap3.Connection(server, receive_timeout=10)
     con.open()
     con.search(search_base="",
                search_filter="(cn={})".format(ldap_cn),


### PR DESCRIPTION
Previously, ldap calls could block indefinitely. With this PR, an exception is raised after a timeout of 10 s, which leads to the return of an empty netgroup in execute_ldapsearch. It looks like callers handle this correctly already.