### PR TITLE
Fix test of control client netgroup check

### DIFF
--- a/test/docker/ldap/Dockerfile
+++ b/test/docker/ldap/Dockerfile
@@ -4,4 +4,5 @@ FROM osixia/openldap:1.4.0
 COPY netgroup.ldif /container/service/slapd/assets/config/bootstrap/ldif/custom/
 COPY remove_all.ldif remove_all.ldif
 COPY remove_eiger.ldif remove_eiger.ldif
+COPY remove_control_client.ldif remove_control_client.ldif
 COPY add_all.ldif add_all.ldif

--- a/test/docker/ldap/remove_control_client.ldif
+++ b/test/docker/ldap/remove_control_client.ldif
@@ -1,0 +1,10 @@
+dn: cn=a3p00-hosts,ou=netgroup,o=hidra
+changetype: modify
+replace: nisNetgroupTriple
+nisNetgroupTriple: (sender-freeze.hidra.test,-,)
+nisNetgroupTriple: (sender-debian.hidra.test,-,)
+nisNetgroupTriple: (sender-debian10.hidra.test,-,)
+nisNetgroupTriple: (sender-debian11.hidra.test,-,)
+nisNetgroupTriple: (sender-suse.hidra.test,-,)
+nisNetgroupTriple: (eiger.hidra.test,-,)
+nisNetgroupTriple: (transfer-client.hidra.test,-,)


### PR DESCRIPTION
When Hidra is not aware of the beamline, the control client immediately fails instead of checking the netgroup and the test failed.