### PR TITLE
Fix http events history bug

### DIFF
--- a/src/hidra/sender/eventdetectors/http_events.py
+++ b/src/hidra/sender/eventdetectors/http_events.py
@@ -88,9 +88,9 @@ class FileFilterDeque:
         for file_obj in files_stored:
             if (file_obj.startswith(self.fix_subdirs)
                     and file_obj not in self.files_seen):
-                self.files_seen.append(file_obj)
                 new_files.append(file_obj)
 
+        self.files_seen.extend(new_files)
         return new_files
 
 

--- a/test/pytest/sender/eventdetectors/test_http_events.py
+++ b/test/pytest/sender/eventdetectors/test_http_events.py
@@ -161,8 +161,6 @@ def test_filter_seen_history_size(file_filter):
     filename = "current/raw/filename11.ext"
     files.append(filename)
     ret = file_filter.get_new_files(files)
-    # ret now contains all files, which is a bug
-    pytest.skip()
     assert ret == ["current/raw/filename0.ext", filename]
 
 


### PR DESCRIPTION
When the number of stored files is larger than the history size, the file filter could return all files as new. Now only files that were dropped from history due to reaching the maximum length are returned in addition to the new files.

Note that using the special `history_size: -1` setting is strongly recommend because it avoids problems with a positive history size that cannot be fixed.