### PR TITLE
Allow use of asapo for commissioning beamtimes

### DIFF
--- a/src/hidra/receiver/plugins/asapo_producer.py
+++ b/src/hidra/receiver/plugins/asapo_producer.py
@@ -78,9 +78,11 @@ logger = logging.getLogger(__name__)
 def get_exposed_path(metadata):
     exposed_path = Path(metadata["relative_path"],
                         metadata["filename"]).parts
-    # asapo work on the core fs only at the moment thus the current
-    # directory does not exist there
-    if exposed_path[0] == "current":
+    # Asapo stores data only under "current" or "commissioning" depending on what kind
+    # of beamtime is currently open.
+    # Ensure that the file comes from one of these places and drop this folder from the
+    # exposed path because that is what Asapo expects
+    if exposed_path[0] in ["current", "commissioning"]:
         exposed_path = Path().joinpath(*exposed_path[1:]).as_posix()
     else:
         raise utils.NotSupported(

--- a/test/pytest/receiver/plugins/test_asapo_producer.py
+++ b/test/pytest/receiver/plugins/test_asapo_producer.py
@@ -72,6 +72,26 @@ def test_worker_create_producer(worker, mock_create_producer, config):
     )
 
 
+def test_worker_create_producer_commissioning(worker, mock_create_producer, config):
+    filepath = "/tmp/hidra_source/current/raw/det01/stream100_scan0-107.tif"
+    metadata = {
+        "relative_path": "commissioning/raw/det01",
+        "filename": "stream100_scan0-107.tif"
+    }
+    worker.send_message(filepath, metadata)
+
+    mock_create_producer.assert_called_once_with(
+        config["endpoint"],
+        'raw',
+        config["beamtime"],
+        config.get("beamline", "auto"),
+        config["default_data_source"],
+        config["token"],
+        config["n_threads"],
+        config.get("timeout", 5) * 1000,
+    )
+
+
 def test_worker_send_message(worker, mock_producer):
     filepath = "/tmp/hidra_source/current/raw/det01/stream100_scan0-107.tif"
     metadata = {


### PR DESCRIPTION
Asapo currently works with commissioning beamtimes if no real beamtime is open at the same time.

This commit removes the restriction for files to come from `current/` and allows files from `commissioning/` to be ingested to Asapo as well.

Note that with this change, data from `commissioning/` can end up in `current/` if a real beamtime is open at the same time as a commissioning beamtime.