### PR TITLE
Use hidra-desy repository for desy-specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore files copied from desy submodule
+src/api/python/hidra/constants.py
+
 *.swp
 *.o
 *.x

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "desy"]
+	path = desy
+	url = git@gitlab.desy.de:fs-sc/hidra-desy.git

--- a/scripts/package_building/alma_build_hidra.sh
+++ b/scripts/package_building/alma_build_hidra.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ex
 
 get_hidra_version()
 {
@@ -95,20 +96,19 @@ IN_DOCKER_DIR=~/rpmbuild
 
 prepare_build
 
-if git show-ref --verify --quiet refs/heads/local_patches; then
-    # a branch named local_patches exists locally
-    # see https://stackoverflow.com/q/5167957
-    CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-    git checkout local_patches
-    git rebase "${CURRENT_BRANCH}"
+
+HIDRA_DESY_DIR=${HIDRA_DIR}/desy
+
+if git -C ${HIDRA_DESY_DIR} show-ref --verify --quiet refs/heads/main; then
+    # The DESY submodule exists
+    # TODO: Check that repo is clean
+    ADD_CONSTANTS="--prefix=hidra-${HIDRA_VERSION}/src/api/python/hidra/ --add-file ${HIDRA_DESY_DIR}/src/api/python/hidra/constants.py"
+else
+    ADD_CONSTANTS=""
 fi
 
-git archive --format tar --prefix="hidra-${HIDRA_VERSION}/" -o "${BUILD_DIR}/SOURCES/hidra-${HIDRA_VERSION}.tar.gz" HEAD
+git archive --format tar ${ADD_CONSTANTS} --prefix="hidra-${HIDRA_VERSION}/" -o "${BUILD_DIR}/SOURCES/hidra-${HIDRA_VERSION}.tar.gz" HEAD
 cp package/hidra.spec "${BUILD_DIR}/SPECS"
-
-if git show-ref --verify --quiet refs/heads/local_patches; then
-    git checkout "${CURRENT_BRANCH}"
-fi
 
 sed -i "s/${NEXT_HIDRA_VERSION}/${HIDRA_VERSION}/" "${BUILD_DIR}/SPECS/hidra.spec"
 

--- a/scripts/package_building/centos_build_hidra.sh
+++ b/scripts/package_building/centos_build_hidra.sh
@@ -73,20 +73,19 @@ IN_DOCKER_DIR=~/rpmbuild
 
 prepare_build
 
-if git show-ref --verify --quiet refs/heads/local_patches; then
-    # a branch named local_patches exists locally
-    # see https://stackoverflow.com/q/5167957
-    CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-    git checkout local_patches
-    git rebase "${CURRENT_BRANCH}"
+HIDRA_DESY_DIR=${HIDRA_DIR}/desy
+
+if git -C ${HIDRA_DESY_DIR} show-ref --verify --quiet refs/heads/main; then
+    # The DESY submodule exists
+    # TODO: Check that repo is clean
+    ADD_CONSTANTS="--prefix=hidra-${HIDRA_VERSION}/src/api/python/hidra/ --add-file ${HIDRA_DESY_DIR}/src/api/python/hidra/constants.py"
+else
+    ADD_CONSTANTS=""
 fi
 
-git archive --format tar --prefix="hidra-${HIDRA_VERSION}/" -o "${BUILD_DIR}/SOURCES/hidra-${HIDRA_VERSION}.tar.gz" HEAD
+
+git archive --format tar ${ADD_CONSTANTS} --prefix="hidra-${HIDRA_VERSION}/" -o "${BUILD_DIR}/SOURCES/hidra-${HIDRA_VERSION}.tar.gz" HEAD
 cp package/hidra.spec "${BUILD_DIR}/SPECS"
-
-if git show-ref --verify --quiet refs/heads/local_patches; then
-    git checkout "${CURRENT_BRANCH}"
-fi
 
 sed -i "s/${NEXT_HIDRA_VERSION}/${HIDRA_VERSION}/" "${BUILD_DIR}/SPECS/hidra.spec"
 

--- a/scripts/package_building/debian_build_hidra.sh
+++ b/scripts/package_building/debian_build_hidra.sh
@@ -118,16 +118,15 @@ download_hidra()
         # local directory can contain unnecessary data or files
         git clone "$HIDRA_LOCATION" "$MAPPED_DIR"/hidra
 
-        pushd "$MAPPED_DIR"/hidra
-        if git show-ref --verify --quiet refs/remotes/origin/local_patches; then
-            # a branch named local_patches exists locally
-            # see https://stackoverflow.com/q/5167957
-            CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-            git checkout local_patches
-            git config user.email "tim.schoof@desy.de" && git config user.name "Tim Schoof"
-            git rebase "${CURRENT_BRANCH}"
+        HIDRA_DESY_DIR="${HIDRA_LOCATION}"/desy
+
+        if git -C "${HIDRA_DESY_DIR}" show-ref --verify --quiet refs/heads/main; then
+            # The DESY submodule exists
+            # TODO: Check that repo is clean
+            cp "${HIDRA_DESY_DIR}/src/api/python/hidra/constants.py" \
+               "${MAPPED_DIR}/hidra/src/api/python/hidra/constants.py"
         fi
-        popd
+
         return
     fi
 

--- a/scripts/package_building/do_manylinux_build_hidra.sh
+++ b/scripts/package_building/do_manylinux_build_hidra.sh
@@ -6,12 +6,11 @@ set -uex
 
 cd /hidra
 
-if git show-ref --verify --quiet refs/heads/local_patches; then
-    # a branch named local_patches exists locally
-    # see https://stackoverflow.com/q/5167957
-    CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-    git checkout local_patches
-    git rebase "${CURRENT_BRANCH}"
+if git -C desy show-ref --verify --quiet refs/heads/main; then
+    # The DESY submodule exists
+    # TODO: Check that repo is clean
+    cp "desy/src/api/python/hidra/constants.py" \
+       "src/api/python/hidra/constants.py"
 fi
 
 # freeze
@@ -40,11 +39,6 @@ $PYBIN freeze_setup.py build
 # zlib.so is dynamically linked against libpython but cx_freeze does not care
 # set rpath tp workaround this
 # /usr/local/bin/patchelf --set-rpath '${ORIGIN}' build/exe.linux-x86_64-3.7/lib/zlib.so
-
-if git show-ref --verify --quiet refs/heads/local_patches; then
-    git checkout "${CURRENT_BRANCH}"
-fi
-
 
 # package
 HIDRA_DIR=$(pwd)

--- a/scripts/package_building/do_windows_build_hidra.sh
+++ b/scripts/package_building/do_windows_build_hidra.sh
@@ -18,26 +18,18 @@ py_ver=$($PYBIN -c 'import platform; print(platform.python_version())')
 py_ver=${py_ver%.*}
 [[ $py_ver =~ 3\.(7|8|9|10|11|12) ]] || exit 1
 
-if git show-ref --verify --quiet refs/heads/local_patches; then
-    # a branch named local_patches exists locally
-    # see https://stackoverflow.com/q/5167957
-    CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-    git checkout local_patches
-    git rebase "${CURRENT_BRANCH}"
+if git -C desy show-ref --verify --quiet refs/heads/main; then
+    # The DESY submodule exists
+    # TODO: Check that repo is clean
+    cp "desy/src/api/python/hidra/constants.py" \
+       "src/api/python/hidra/constants.py"
 fi
-
 # freeze
 
 $PYBIN -m pip install cx_freeze
 $PYBIN -m pip install --prefer-binary -r win-requirements.txt
 
 $PYBIN freeze_setup.py build
-
-
-if git show-ref --verify --quiet refs/heads/local_patches; then
-    git checkout "${CURRENT_BRANCH}"
-fi
-
 
 # package
 HIDRA_DIR="$(pwd)"

--- a/src/api/python/hidra/_constants.py
+++ b/src/api/python/hidra/_constants.py
@@ -27,10 +27,15 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-
-CONNECTION_LIST = {
-    "p00": {
-        "host": "asap3-p00",
-        "port": 51000
-    },
+try:
+    from .constants import CONNECTION_LIST
+except ImportError:
+    # Using ImportError instead of ModuleNotFoundError to support Python 2. This would
+    # hide a typo in the imported variable name, but other errors in the imported
+    # module, e.g. SyntaxError, would still be surfaced.
+    CONNECTION_LIST = {
+        "p00": {
+            "host": "asap3-p00",
+            "port": 51000
+        },
 }


### PR DESCRIPTION
The hidra-desy repository is included as a git submodule.  If the submodule was initialized via `git submodule update --init --recursive`, the desy-specific files from the submodule are included into all packages during the build. Otherwise, the packages are built without the files.